### PR TITLE
Remove async ref when exit signaled

### DIFF
--- a/src/retest_sh.erl
+++ b/src/retest_sh.erl
@@ -77,7 +77,7 @@ run(Cmd, Opts) ->
 stop(Ref) ->
     #sh { pid = Pid, port = Port } = erlang:get(Ref),
     _ = os:cmd(?FMT("kill ~s", [Pid])),
-    exit_loop(Port).
+    exit_loop(Ref, Port).
 
 stop_all() ->
     _ = [ {ok, _} = stop(Ref) || {Ref, Sh} <- erlang:get(),
@@ -109,13 +109,14 @@ read_pid(Port) ->
             {error, {stopped, Rc}}
     end.
 
-exit_loop(Port) ->
+exit_loop(Ref, Port) ->
     receive
         {Port, {data, {_, Line}}} ->
             ?DEBUG("~p: ~s\n", [erlang:get(retest_module), Line]),
-            exit_loop(Port);
+            exit_loop(Ref, Port);
 
         {Port, {exit_status, Rc}} ->
+            erlang:erase(Ref),
             {ok, Rc}
     end.
 


### PR DESCRIPTION
When calling retest_sh:stop/1 on a Ref and thereby shutting down a process, a subsequent
retest_sh:all/0 will timeout, as it still considers Ref to be valid and will hence wait
for its process to complete. As this process does not exist anymore, this will never happen.
