### PR TITLE
Escape whitespace in paths

### DIFF
--- a/src/retest_core.erl
+++ b/src/retest_core.erl
@@ -64,7 +64,7 @@ run(Args) ->
                     OutDir = filename:absname(filename:join(retest_config:get(out_dir), RunId)),
                     OutDirLink = filename:join(filename:dirname(OutDir), "current"),
                     ok = filelib:ensure_dir(OutDir ++ "/dummy"),
-                    [] = os:cmd(?FMT("rm -f ~s; ln -sf ~s ~s", [OutDirLink, OutDir,
+                    [] = os:cmd(?FMT("rm -f '~s'; ln -sf '~s' '~s'", [OutDirLink, OutDir,
                                                                 OutDirLink])),
                     retest_config:set(run_dir, OutDir),
                     retest_config:set(run_id, RunId),


### PR DESCRIPTION
Paths in os:cmd/1 should always be escaped.
