### PR TITLE
Allow command line test timeout configuration

### DIFF
--- a/src/retest_core.erl
+++ b/src/retest_core.erl
@@ -94,7 +94,8 @@ options() ->
      {help,     $h, "help",     boolean, "Show the program options"},
      {verbose,  $v, "verbose",  boolean, "Use debug level output"},
      {outdir,   $o, "outdir",   string,  "Directory to use for all test output"},
-     {loglevel, $l, "loglevel", atom,    "Log output level: error, warn, info, debug"}
+     {loglevel, $l, "loglevel", atom,    "Log output level: error, warn, info, debug"},
+     {timeout,  $t, "timeout",  integer, "Timeout value to apply to all tests (default: 30 seconds)"}
     ].
 
 merge_options([]) ->
@@ -112,6 +113,9 @@ merge_options([{loglevel, Level} | Rest]) ->
         false ->
             ok
     end,
+    merge_options(Rest);
+merge_options([{timeout, Timeout} | Rest]) ->
+    application:set_env(retest, timeout, Timeout),
     merge_options(Rest);
 merge_options([_Option | Rest]) ->
     merge_options(Rest).

--- a/test/retest_SUITE.erl
+++ b/test/retest_SUITE.erl
@@ -16,7 +16,7 @@ suite() -> [].
 
 all() ->
     [basic_run, basic_run_all_args, directory_does_not_exist,
-     wrong_arguments, test_exceeds_timeout,
+     wrong_arguments, test_exceeds_timeout, test_exceeds_custom_timeout,
      create, copy, template, replace, touch, create_dir,
      logging, shell_api, shell_async_api, shell_async_api].
 
@@ -67,6 +67,16 @@ test_exceeds_timeout(doc) -> ["Does retest correctly tests that exceed the confi
 test_exceeds_timeout(suite) -> [];
 test_exceeds_timeout(Config) when is_list(Config) ->
     ?assertException(throw, abort, retest_run("long_test", Config)).
+
+test_exceeds_custom_timeout(doc) -> ["Does retest correctly tests that exceed the custom timeout passed on the command line"];
+test_exceeds_custom_timeout(suite) -> [];
+test_exceeds_custom_timeout(Config) when is_list(Config) ->
+    {_, S0, _} = os:timestamp(),
+    ?assertException(throw, abort, retest_run("long_test_custom_timeout",
+                                              ["--timeout", "2000"], Config)),
+    {_, S1, _} = os:timestamp(),
+    %% there should only have elapsed 2s
+    2 = S1 - S0.
 
 copy(doc) -> ["Test copy directive"];
 copy(suite) -> [];

--- a/test/retest_SUITE_data/long_test_custom_timeout/long_test_custom_timeout_rt.erl
+++ b/test/retest_SUITE_data/long_test_custom_timeout/long_test_custom_timeout_rt.erl
@@ -1,0 +1,8 @@
+-module(long_test_custom_timeout_rt).
+
+-include_lib("eunit/include/eunit.hrl").
+
+files() -> [].
+
+run(_Dir) ->
+    ok = timer:sleep(60000).


### PR DESCRIPTION
On some platforms (eg. Windows) tests might run
a bit slower thus hitting the timeout ceiling,
instead of defining a separate timeout for each
test provide a way to override the default value
through a command line option.