### PR TITLE
Add create_dir directive

### DIFF
--- a/src/retest_utils.erl
+++ b/src/retest_utils.erl
@@ -151,6 +151,15 @@ execute_cmds([{touch, Filename0} | Rest], BaseDir, TargetDir) ->
         {error, Reason} ->
             ?ABORT("Failed to touch ~p: ~p\n", [Filename1, Reason])
     end;
+execute_cmds([{create_dir, Out} | Rest], BaseDir, TargetDir) ->
+    Dir = filename:join(TargetDir, Out),
+    case file:make_dir(Dir) of
+        ok ->
+            ?DEBUG("Created directory ~p\n", [Dir]),
+            execute_cmds(Rest, BaseDir, TargetDir);
+        {error, Reason} ->
+            ?ABORT("Failed to create dir ~p: ~p\n", [Dir, Reason])
+    end;
 execute_cmds([Other | _Rest], _BaseDir, _TargetDir) ->
     {error, {unsupported_operation, Other}}.
 

--- a/test/retest_SUITE.erl
+++ b/test/retest_SUITE.erl
@@ -17,7 +17,7 @@ suite() -> [].
 all() ->
     [basic_run, basic_run_all_args, directory_does_not_exist,
      wrong_arguments, test_exceeds_timeout,
-     create, copy, template, replace, touch,
+     create, copy, template, replace, touch, create_dir,
      logging, shell_api, shell_async_api, shell_async_api].
 
 groups() ->
@@ -92,6 +92,11 @@ touch(doc) -> ["Test touch directive"];
 touch(suite) -> [];
 touch(Config) when is_list(Config)->
     ok = retest_run("touch", Config).
+
+create_dir(doc) -> ["Test create_dir directive"];
+create_dir(suite) -> [];
+create_dir(Config) when is_list(Config)->
+    ok = retest_run("create_dir", Config).
 
 logging(doc) -> ["Test logging"];
 logging(suite) -> [];

--- a/test/retest_SUITE_data/create_dir/create_dir_rt.erl
+++ b/test/retest_SUITE_data/create_dir/create_dir_rt.erl
@@ -1,0 +1,10 @@
+-module(touch_rt).
+
+-include_lib("eunit/include/eunit.hrl").
+
+files() ->
+    [{create_dir, "dir1"}].
+
+run(Dir) ->
+    true = filelib:is_dir("dir1"),
+    ok.


### PR DESCRIPTION
Useful for when you need to execute tests that require
empty dirs for output to be generated into, current
method requires us to add some file to the dir.